### PR TITLE
Implement Metric Collector that uses Likwid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ tvm_option(INDEX_DEFAULT_I64 "Defaults the index datatype to int64" ON)
 tvm_option(USE_LIBBACKTRACE "Build libbacktrace to supply linenumbers on stack traces" AUTO)
 tvm_option(BUILD_STATIC_RUNTIME "Build static version of libtvm_runtime" OFF)
 tvm_option(USE_PAPI "Use Performance Application Programming Interface (PAPI) to read performance counters" OFF)
+tvm_option(USE_LIKWID "Use Likwid to read performance counters" OFF)
 tvm_option(USE_GTEST "Use GoogleTest for C++ sanity tests" AUTO)
 tvm_option(USE_CUSTOM_LOGGING "Use user-defined custom logging, tvm::runtime::detail::LogFatalImpl and tvm::runtime::detail::LogMessageImpl must be implemented" OFF)
 tvm_option(USE_ALTERNATIVE_LINKER "Use 'mold' or 'lld' if found when invoking compiler to link artifact" AUTO)
@@ -553,6 +554,8 @@ target_compile_definitions(tvm_runtime PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runt
 include(cmake/modules/Logging.cmake)
 
 include(cmake/modules/contrib/PAPI.cmake)
+
+include(cmake/modules/contrib/Likwid.cmake)
 
 if(USE_MICRO)
   # NOTE: cmake doesn't track dependencies at the file level across subdirectories. For the

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -360,6 +360,8 @@ set(BUILD_STATIC_RUNTIME OFF)
 # - /path/to/folder/containing/: Path to folder containing papi.pc.
 set(USE_PAPI OFF)
 
+set(USE_LIKWID ON)
+
 # Whether to use GoogleTest for C++ unit tests. When enabled, the generated
 # build file (e.g. Makefile) will have a target "cpptest".
 # Possible values:

--- a/cmake/modules/contrib/Likwid.cmake
+++ b/cmake/modules/contrib/Likwid.cmake
@@ -1,0 +1,7 @@
+if (USE_LIKWID)
+  message(STATUS "Using Likwid library")
+  target_link_libraries(tvm_runtime_objs PRIVATE -llikwid)
+  target_link_libraries(tvm PRIVATE -llikwid)
+  target_link_libraries(tvm_runtime PRIVATE -llikwid)
+  target_sources(tvm_runtime_objs PRIVATE src/runtime/contrib/likwid/likwid.cc)
+endif()

--- a/include/tvm/runtime/contrib/likwid.h
+++ b/include/tvm/runtime/contrib/likwid.h
@@ -1,0 +1,18 @@
+#ifndef TVM_RUNTIME_CONTRIB_LIKWID_H_
+#define TVM_RUNTIME_CONTRIB_LIKWID_H_
+
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/map.h>
+#include <tvm/runtime/profiling.h>
+
+namespace tvm {
+namespace runtime {
+namespace profiling {
+
+TVM_DLL MetricCollector CreateLikwidMetricCollector(Array<DeviceWrapper> devices);
+
+} // namespace profiling
+} // namespace runtime
+} // namespace tvm
+
+#endif // TVM_RUNTIME_CONTRIB_LIKWID_H_

--- a/python/tvm/runtime/profiling/__init__.py
+++ b/python/tvm/runtime/profiling/__init__.py
@@ -291,3 +291,14 @@ if _ffi.get_global_func("runtime.profiling.PAPIMetricCollector", allow_missing=T
             for dev, names in metric_names.items():
                 wrapped[DeviceWrapper(dev)] = names
             self.__init_handle_by_constructor__(_ffi_api.PAPIMetricCollector, wrapped)
+
+
+# We only enable this class when TVM is build with Likwid support
+if _ffi.get_global_func("runtime.profiling.LikwidMetricCollector", allow_missing=True) is not None:
+    
+    @_ffi.register_object("runtime.profiling.LikwidMetricCollector")
+    class LikwidMetricCollector(MetricCollector):
+
+        def __init__(self, devices: Optional[Sequence[Device]] = None):
+            wrapped_devices = [DeviceWrapper(dev) for dev in devices]
+            self.__init_handle_by_constructor__(_ffi_api.LikwidMetricCollector, wrapped_devices)

--- a/src/runtime/contrib/likwid/likwid.cc
+++ b/src/runtime/contrib/likwid/likwid.cc
@@ -1,0 +1,113 @@
+#include <likwid.h>
+
+#include <string>
+#include <vector.h>
+#include <profiling.h>
+
+#ifdef LIKWID_PERFMON
+#include <likwid-marker.h>
+#else
+#define LIKWID_MARKER_INIT
+#define LIKWID_MARKER_THREADINIT
+#define LIKWID_MARKER_SWITCH
+#define LIKWID_MARKER_REGISTER(regionTag)
+#define LIKWID_MARKER_START(regionTag)
+#define LIKWID_MARKER_STOP(regionTag)
+#define LIKWID_MARKER_CLOSE
+#define LIKWID_MARKER_GET(regionTag, nevents, events, time, count)
+#endif
+
+namespace tvm {
+namespace runtime {
+namespace profiling {
+
+struct LikwidEventSetNode : public Object {
+    std::vector<double> start_values;
+    Device dev;
+
+    explicit LikwidEventSetNode(std::vector<double> start_values, Device dev) 
+        : start_values(start_values), dev(dev) {}
+
+    static constexpr const char* _type_key = "LikwidEventSetNode";
+    TVM_DECLARE_FINAL_OBJECT_INFO(LikwidEventSetNode, Object);
+};
+
+struct LikwidMetricCollectorNode final : public MetricCollectorNode {
+    void Init(Array<DeviceWrapper> devices) override {
+        likwid_markerInit();
+        likwid_markerThreadInit();
+        likwid_markerRegisterRegion("MetricCollectorNode");
+    }
+
+    ObjectRef Start(Device device) override {
+        int res = likwid_markerStartRegion("MetricCollectorNode");
+        if (res < 0) {
+            LOG(ERROR) << "Marker region could not be started! Error code: " << res;
+            return ObjectRef(nullptr);
+        }
+        int nevents = 10;
+        double events[10];
+        double time;
+        int count;
+        likwid_markerGetRegion("LikwidEventSetNode", &nevents, events, &time, &count);
+        if (count == 0) {
+            LOG(WARNING) << "Event count is zero!";
+        }
+        std::vector<double> start_values(std::begin(events), std::end(events));
+        return ObjectRef(make_object<LikwidEventSetNode>(start_values, device));
+    }
+
+    Map<String, ObjectRef> Stop(ObjectRef object) override {
+        const LikwidEventSetNode* event_set_node = object.as<LikwidEventSetNode>();
+        int nevents = 10;
+        double events[10];
+        double time;
+        int count;
+        likwid_markerGetRegion("LikwidEventSetNode", &nevents, events, &time, &count);
+        std::vector<double> end_values(std::begin(events), std::end(events));
+        std::unordered_map<String, ObjectRef> reported_metrics;
+        for (size_t i{}; i < end_values.size(); ++i) {
+            if (end_values[i] < event_set_node->start_values[i]) {
+                LOG(WARNING) << "Detected overflow while reading performance counter, setting value to -1";
+                reported_metrics[String(std::to_string(i))] = 
+                    ObjectRef(make_object<CountNode>(-1));
+            } else {
+                reported_metrics[String(std::to_string(i))] = 
+                    ObjectRef(make_object<CountNode>(end_values[i] - event_set_node->start_values[i]));
+            }
+        }
+        int res = likwid_markerStopRegion("LikwidEventSetNode");
+        if (res < 0) {
+            LOG(ERROR) << "Could not close marker region! Error code: " << res;
+        }
+        return reported_metrics;
+    }
+
+    ~LikwidMetricCollectorNode() final {
+        likwid_markerClose();
+    }
+
+    static constexpr const char* _type_key = "runtime.profiling.LikwidMetricCollector";
+    TVM_DECLARE_FINAL_OBJECT_INFO(LikwidMetricCollectorNode, MetricCollectorNode);
+};
+
+class LikwidMetricCollector : public MetricCollector {
+public:
+    explicit LikwidMetricCollector(Array<DeviceWrapper> devices) {
+        data_ = make_object<LikwidMetricCollectorNode>(devices);
+    }
+    TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(LikwidMetricCollector, MetricCollector, 
+                                          LikwidMetricCollectorNode);
+};
+
+TVM_REGISTER_OBJECT_TYPE(LikwidEventSetNode);
+TVM_REGISTER_OBJECT_TYPE(LikwidMetricCollectorNode);
+
+TVM_REGISTER_GLOBAL("runtime.profiling.LikwidMetricCollector")
+    .set_body_typed([](Array<DeviceWrapper> devices) {
+        return LikwidMetricCollector(devices);
+    });
+
+} // namespace profiling
+} // namespace runtime
+} // namespace tvm

--- a/src/runtime/contrib/likwid/likwid.cc
+++ b/src/runtime/contrib/likwid/likwid.cc
@@ -1,8 +1,8 @@
 #include <likwid.h>
+#include <tvm/runtime/contrib/likwid.h>
 
 #include <string>
-#include <vector.h>
-#include <profiling.h>
+#include <vector>
 
 #ifdef LIKWID_PERFMON
 #include <likwid-marker.h>
@@ -33,6 +33,12 @@ struct LikwidEventSetNode : public Object {
 };
 
 struct LikwidMetricCollectorNode final : public MetricCollectorNode {
+    explicit LikwidMetricCollectorNode(Array<DeviceWrapper> devices) {
+        // Do nothing for now...
+    }
+
+    explicit LikwidMetricCollectorNode() {}
+
     void Init(Array<DeviceWrapper> devices) override {
         likwid_markerInit();
         likwid_markerThreadInit();


### PR DESCRIPTION
Implement a first proof-of-concept version of a custom `MetricCollector` called `LikwidMetricCollector` that can be used to gather hardware event counters at runtime if `TVM` is run thorugh the `likwid-perfctr` wrapper application.